### PR TITLE
Add X-cell paper to Foundation-Model-Genetic-Perturbation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@
 
 
 ## Foundation-Model-Genetic-Perturbation
+1. [2026 bioRxiv] **X-Cell: Scaling Causal Perturbation Prediction Across Diverse Cellular Contexts via Diffusion Language Models** [[paper]](https://www.biorxiv.org/content/10.64898/2026.03.18.712807v1)
 1. [2025 PNAS] **Predicting the unseen: A diffusion-based debiasing framework for transcriptional response prediction at single-cell resolution** [[paper]](https://www.pnas.org/doi/10.1073/pnas.2525268122)
 1. [2025 bioRxiv] **Tahoe-100M: A Giga-Scale Single-Cell Perturbation Atlas for Context-Dependent Gene Function and Cellular Modeling** [[paper]](https://www.biorxiv.org/content/10.1101/2025.02.20.639398v3)
 1. [2025 biorxiv] **Tahoe-x1: Scaling Perturbation-Trained Single-Cell Foundation Models to 3 Billion Parameters** [[paper]](https://www.biorxiv.org/content/10.1101/2025.10.23.683759v1)


### PR DESCRIPTION
Hi! I'm adding a recently released bioRxiv paper: *X-Cell: Scaling Causal Perturbation Prediction Across Diverse Cellular Contexts via Diffusion Language Models*. 

I placed it under the **Foundation-Model-Genetic-Perturbation** section rather than the general FM section, as its primary focus and contribution lie in causal perturbation prediction.